### PR TITLE
Re-create CLF API for review PR

### DIFF
--- a/manifests/4.6/logforwardings.crd.yaml
+++ b/manifests/4.6/logforwardings.crd.yaml
@@ -1,0 +1,87 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: logforwardings.logging.openshift.io
+spec:
+  group: logging.openshift.io
+  names:
+    kind: LogForwarding
+    listKind: LogForwardingList
+    plural: logforwardings
+    singular: logforwarding
+  scope: Namespaced
+  version: v1alpha1
+  validation:
+    openAPIV3Schema:
+      type: object
+      properties:
+        spec:
+          type: object
+          description: Specification for logforwarding of messages
+          properties:
+            outputs:
+              description: Destinations for log messages
+              items:
+                type: object
+                description: An individual entry for a specific output
+                properties:
+                  type:
+                    description: The output type (e.g. elasticsearch or logstore)
+                    type: string
+                    enum:
+                      - elasticsearch
+                      - forward
+                      - syslog
+                  name: 
+                    description: The name of the output
+                    type: string
+                  endpoint:
+                    description: the url to the the service defined by this output
+                    type: string
+                  secret:
+                    properties:
+                      name:
+                        description: The name of a secret to mount into the collector to use when shipping logs
+                        type: string
+                    required:
+                      - name
+                    type: object
+                    nullable: true
+              required:
+              - type
+              - name
+              - endpoint
+              type: array
+            pipelines:
+              description: The mapping of sources to outputs
+              items:
+                type: object
+                properties:
+                  name:
+                    description: The name of the pipeline
+                    type: string
+                  outputRefs:
+                    description: The name of outputs to send the source logs
+                    items:
+                      type: string
+                    type: array
+                  inputSource:
+                    description: The log source type
+                    type: string
+                    enum:
+                      - logs.app
+                      - logs.infra
+                      - logs.audit
+              required:
+              - name
+              - source
+              - outputRefs
+              type: array
+          required:
+          - outputs
+          - pipelines
+        status:
+          type: object
+  subresources:
+    status: {}
+

--- a/manifests/4.6/logging.openshift.io_clusterlogforwarders_crd.yaml
+++ b/manifests/4.6/logging.openshift.io_clusterlogforwarders_crd.yaml
@@ -1,0 +1,419 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterlogforwarders.logging.openshift.io
+spec:
+  group: logging.openshift.io
+  names:
+    kind: ClusterLogForwarder
+    listKind: ClusterLogForwarderList
+    plural: clusterlogforwarders
+    shortNames:
+    - clf
+    singular: clusterlogforwarder
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ClusterLogForwarder is an API to configure forwarding logs.
+          \n You configure forwarding by specifying a list of `pipelines`, which forward
+          from a set of named inputs to a set of named outputs. \n There are built-in
+          input names for common log categories, and you can define custom inputs
+          to do additional filtering. \n There is a built-in output name for the default
+          openshift log store, but you can define your own outputs with a URL and
+          other connection information to forward logs to other stores or processors,
+          inside or outside the cluster. \n For more details see the documentation
+          on the API fields."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - instance
+                type: string
+            type: object
+          spec:
+            description: ClusterLogForwarderSpec defines the desired state of ClusterLogForwarder
+            properties:
+              inputs:
+                description: "Inputs are named filters for log messages to be forwarded.
+                  \n There are three built-in inputs named `application`, `infrastructure`
+                  and `audit`. You don't need to define inputs here if those are sufficient
+                  for your needs. See `inputRefs` for more."
+                items:
+                  description: InputSpec defines a selector of log messages.
+                  properties:
+                    application:
+                      description: Application, if present, enables `application`
+                        logs.
+                      properties:
+                        namespaces:
+                          description: Namespaces is a list of namespaces from which
+                            to collect application logs. If the list is empty, logs
+                            are collected from all namespaces.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    audit:
+                      description: Audit, if present, enables `audit` logs.
+                      type: object
+                    infrastructure:
+                      description: Infrastructure, if present, enables `infrastructure`
+                        logs.
+                      type: object
+                    name:
+                      description: Name used to refer to the input of a `pipeline`.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              outputs:
+                description: "Outputs are named destinations for log messages. \n
+                  There is a built-in output named `default` which forwards to the
+                  default openshift log store. You can define outputs to forward to
+                  other stores or log processors, inside or outside the cluster."
+                items:
+                  description: Output defines a destination for log messages.
+                  properties:
+                    elasticsearch:
+                      type: object
+                    fluentdForward:
+                      type: object
+                    kafka:
+                      description: 'Kafka provides optional extra properties for `type:
+                        kafka`'
+                      properties:
+                        brokers:
+                          description: Brokers specifies the list of brokers to register
+                            in addition to the main output URL on initial connect
+                            to enhance reliability.
+                          items:
+                            type: string
+                          type: array
+                        topic:
+                          description: Topic specifies the target topic to send logs
+                            to.
+                          type: string
+                      type: object
+                    name:
+                      description: Name used to refer to the output from a `pipeline`.
+                      type: string
+                    secret:
+                      description: "Secret for secure communication. Secrets must
+                        be stored in the namespace containing the cluster logging
+                        operator. \n Client-authenticated TLS is enabled if the secret
+                        contains keys `tls.crt`, `tls.key` and `ca.crt`. Output types
+                        with password authentication will use keys `password` and
+                        `username`, not the exposed 'username@password' part of the
+                        `url`."
+                      properties:
+                        name:
+                          description: Name of a secret in the namespace configured
+                            for log forwarder secrets.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    syslog:
+                      description: Syslog provides optional extra properties for output
+                        type `syslog`
+                      properties:
+                        appName:
+                          description: "AppName is APP-NAME part of the syslog-msg
+                            header \n AppName needs to be specified if using rfc5424"
+                          type: string
+                        facility:
+                          description: "Facility to set on outgoing syslog records.
+                            \n Facility values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1.
+                            The value can be a decimal integer. Facility keywords
+                            are not standardized, this API recognizes at least the
+                            following case-insensitive keywords (defined by https://en.wikipedia.org/wiki/Syslog#Facility_Levels):
+                            \n     kernel user mail daemon auth syslog lpr news     uucp
+                            cron authpriv ftp ntp security console solaris-cron     local0
+                            local1 local2 local3 local4 local5 local6 local7"
+                          type: string
+                        msgID:
+                          description: "MsgID is MSGID part of the syslog-msg header
+                            \n MsgID needs to be specified if using rfc5424"
+                          type: string
+                        payloadKey:
+                          description: PayloadKey specifies record field to use as
+                            payload.
+                          type: string
+                        procID:
+                          description: "ProcID is PROCID part of the syslog-msg header
+                            \n ProcID needs to be specified if using rfc5424"
+                          type: string
+                        rfc:
+                          default: RFC5424
+                          description: "Rfc specifies the rfc to be used for sending
+                            syslog \n Rfc values can be one of:  - RFC3164 (https://tools.ietf.org/html/rfc3164)
+                            \ - RFC5424 (https://tools.ietf.org/html/rfc5424) \n If
+                            unspecified, RFC5424 will be assumed."
+                          enum:
+                          - RFC3164
+                          - RFC5424
+                          type: string
+                        severity:
+                          description: "Severity to set on outgoing syslog records.
+                            \n Severity values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1
+                            The value can be a decimal integer or one of these case-insensitive
+                            keywords: \n     Emergency Alert Critical Error Warning
+                            Notice Informational Debug"
+                          type: string
+                        tag:
+                          description: Tag specifies a record field to use as tag.
+                          type: string
+                        trimPrefix:
+                          description: TrimPrefix is a prefix to trim from the tag.
+                          type: string
+                      type: object
+                    type:
+                      description: Type of output plugin.
+                      enum:
+                      - syslog
+                      - fluentdForward
+                      - elasticsearch
+                      - kafka
+                      type: string
+                    url:
+                      description: "URL to send log messages to. \n Must be an absolute
+                        URL, with a scheme. Valid URL schemes depend on `type`. Special
+                        schemes 'tcp', 'udp' and 'tls' are used for output types that
+                        don't define their own URL scheme.  Example: \n     { type:
+                        syslog, url: tls://syslog.example.com:1234 } \n TLS with server
+                        authentication is enabled by the URL scheme, for example 'tls'
+                        or 'https'.  See `secret` for TLS client authentication."
+                      type: string
+                  required:
+                  - name
+                  - type
+                  type: object
+                type: array
+              pipelines:
+                description: Pipelines forward the messages selected by a set of inputs
+                  to a set of outputs.
+                items:
+                  properties:
+                    inputRefs:
+                      description: "InputRefs lists the names (`input.name`) of inputs
+                        to this pipeline. \n The following built-in input names are
+                        always available: \n `application` selects all logs from application
+                        pods. \n `infrastructure` selects logs from openshift and
+                        kubernetes pods and some node logs. \n `audit` selects node
+                        logs related to security audits."
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      description: Name is optional, but must be unique in the `pipelines`
+                        list if provided.
+                      type: string
+                    outputRefs:
+                      description: "OutputRefs lists the names (`output.name`) of
+                        outputs from this pipeline. \n The following built-in names
+                        are always available: \n 'default' Output to the default log
+                        store provided by ClusterLogging."
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - inputRefs
+                  - outputRefs
+                  type: object
+                type: array
+            type: object
+          status:
+            description: ClusterLogForwarder represents the current status of ClusterLogForwarder
+            properties:
+              conditions:
+                description: Conditions of the log forwarder.
+                items:
+                  description: "Condition represents an observation of an object's
+                    state. Conditions are an extension mechanism intended to be used
+                    when the details of an observation are not a priori known or would
+                    not apply to all instances of a given Kind. \n Conditions should
+                    be added to explicitly convey properties that users and components
+                    care about rather than requiring those properties to be inferred
+                    from other observations. Once defined, the meaning of a Condition
+                    can not be changed arbitrarily - it becomes part of the API, and
+                    has the same backwards- and forwards-compatibility concerns of
+                    any other part of the API."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is intended to be a one-word, CamelCase
+                        representation of the category of cause of the current status.
+                        It is intended to be used in concise output, such as one-line
+                        kubectl get output, and in summarizing occurrences of causes.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: "ConditionType is the type of the condition and
+                        is typically a CamelCased word or short phrase. \n Condition
+                        types should indicate state in the \"abnormal-true\" polarity.
+                        For example, if the condition indicates when a policy is invalid,
+                        the \"is valid\" case is probably the norm, so the condition
+                        should be called \"Invalid\"."
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              inputs:
+                additionalProperties:
+                  description: Conditions is a set of Condition instances.
+                  items:
+                    description: "Condition represents an observation of an object's
+                      state. Conditions are an extension mechanism intended to be
+                      used when the details of an observation are not a priori known
+                      or would not apply to all instances of a given Kind. \n Conditions
+                      should be added to explicitly convey properties that users and
+                      components care about rather than requiring those properties
+                      to be inferred from other observations. Once defined, the meaning
+                      of a Condition can not be changed arbitrarily - it becomes part
+                      of the API, and has the same backwards- and forwards-compatibility
+                      concerns of any other part of the API."
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        description: ConditionReason is intended to be a one-word,
+                          CamelCase representation of the category of cause of the
+                          current status. It is intended to be used in concise output,
+                          such as one-line kubectl get output, and in summarizing
+                          occurrences of causes.
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: "ConditionType is the type of the condition and
+                          is typically a CamelCased word or short phrase. \n Condition
+                          types should indicate state in the \"abnormal-true\" polarity.
+                          For example, if the condition indicates when a policy is
+                          invalid, the \"is valid\" case is probably the norm, so
+                          the condition should be called \"Invalid\"."
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+                description: Inputs maps input name to condition of the input.
+                type: object
+              outputs:
+                additionalProperties:
+                  description: Conditions is a set of Condition instances.
+                  items:
+                    description: "Condition represents an observation of an object's
+                      state. Conditions are an extension mechanism intended to be
+                      used when the details of an observation are not a priori known
+                      or would not apply to all instances of a given Kind. \n Conditions
+                      should be added to explicitly convey properties that users and
+                      components care about rather than requiring those properties
+                      to be inferred from other observations. Once defined, the meaning
+                      of a Condition can not be changed arbitrarily - it becomes part
+                      of the API, and has the same backwards- and forwards-compatibility
+                      concerns of any other part of the API."
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        description: ConditionReason is intended to be a one-word,
+                          CamelCase representation of the category of cause of the
+                          current status. It is intended to be used in concise output,
+                          such as one-line kubectl get output, and in summarizing
+                          occurrences of causes.
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: "ConditionType is the type of the condition and
+                          is typically a CamelCased word or short phrase. \n Condition
+                          types should indicate state in the \"abnormal-true\" polarity.
+                          For example, if the condition indicates when a policy is
+                          invalid, the \"is valid\" case is probably the norm, so
+                          the condition should be called \"Invalid\"."
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+                description: Outputs maps output name to condition of the output.
+                type: object
+              pipelines:
+                additionalProperties:
+                  description: Conditions is a set of Condition instances.
+                  items:
+                    description: "Condition represents an observation of an object's
+                      state. Conditions are an extension mechanism intended to be
+                      used when the details of an observation are not a priori known
+                      or would not apply to all instances of a given Kind. \n Conditions
+                      should be added to explicitly convey properties that users and
+                      components care about rather than requiring those properties
+                      to be inferred from other observations. Once defined, the meaning
+                      of a Condition can not be changed arbitrarily - it becomes part
+                      of the API, and has the same backwards- and forwards-compatibility
+                      concerns of any other part of the API."
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        description: ConditionReason is intended to be a one-word,
+                          CamelCase representation of the category of cause of the
+                          current status. It is intended to be used in concise output,
+                          such as one-line kubectl get output, and in summarizing
+                          occurrences of causes.
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: "ConditionType is the type of the condition and
+                          is typically a CamelCased word or short phrase. \n Condition
+                          types should indicate state in the \"abnormal-true\" polarity.
+                          For example, if the condition indicates when a policy is
+                          invalid, the \"is valid\" case is probably the norm, so
+                          the condition should be called \"Invalid\"."
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+                description: Pipelines maps pipeline name to condition of the pipeline.
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/pkg/apis/logging/v1/cluster_log_forwarder_types.go
+++ b/pkg/apis/logging/v1/cluster_log_forwarder_types.go
@@ -1,0 +1,205 @@
+package v1
+
+import (
+	"github.com/openshift/cluster-logging-operator/pkg/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const ClusterLogForwarderKind = "ClusterLogForwarder"
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:shortName=clf
+
+// ClusterLogForwarder is an API to configure forwarding logs.
+//
+// You configure forwarding by specifying a list of `pipelines`,
+// which forward from a set of named inputs to a set of named outputs.
+//
+// There are built-in input names for common log categories, and you can
+// define custom inputs to do additional filtering.
+//
+// There is a built-in output name for the default openshift log store, but
+// you can define your own outputs with a URL and other connection information
+// to forward logs to other stores or processors, inside or outside the cluster.
+//
+// For more details see the documentation on the API fields.
+//
+type ClusterLogForwarder struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   ClusterLogForwarderSpec   `json:"spec,omitempty"`
+	Status ClusterLogForwarderStatus `json:"status,omitempty"`
+}
+
+// ClusterLogForwarderSpec defines the desired state of ClusterLogForwarder
+type ClusterLogForwarderSpec struct {
+	// Inputs are named filters for log messages to be forwarded.
+	//
+	// There are three built-in inputs named `application`, `infrastructure` and
+	// `audit`. You don't need to define inputs here if those are sufficient for
+	// your needs. See `inputRefs` for more.
+	//
+	// +optional
+	Inputs []InputSpec `json:"inputs,omitempty"`
+
+	// Outputs are named destinations for log messages.
+	//
+	// There is a built-in output named `default` which forwards to the default
+	// openshift log store. You can define outputs to forward to other stores or
+	// log processors, inside or outside the cluster.
+	//
+	// +optional
+	Outputs []OutputSpec `json:"outputs,omitempty"`
+
+	// Pipelines forward the messages selected by a set of inputs to a set of outputs.
+	//
+	// +required
+	Pipelines []PipelineSpec `json:"pipelines,omitempty"`
+}
+
+// ClusterLogForwarder represents the current status of ClusterLogForwarder
+type ClusterLogForwarderStatus struct {
+	// Conditions of the log forwarder.
+	Conditions status.Conditions `json:"conditions,omitempty"`
+	// Inputs maps input name to condition of the input.
+	Inputs NamedConditions `json:"inputs,omitempty"`
+	// Outputs maps output name to condition of the output.
+	Outputs NamedConditions `json:"outputs,omitempty"`
+	// Pipelines maps pipeline name to condition of the pipeline.
+	Pipelines NamedConditions `json:"pipelines,omitempty"`
+}
+
+// InputSpec defines a selector of log messages.
+type InputSpec struct {
+	// Name used to refer to the input of a `pipeline`.
+	//
+	// +kubebuilder:validation:minLength:=1
+	// +required
+	Name string `json:"name"`
+
+	// NOTE: the following fields in this struct are deliberately _not_ `omitempty`.
+	// An empty field means enable that input type with no filter.
+
+	// Application, if present, enables `application` logs.
+	//
+	// +optional
+	Application *Application `json:"application"`
+
+	// Infrastructure, if present, enables `infrastructure` logs.
+	//
+	// +optional
+	Infrastructure *Infrastructure `json:"infrastructure"`
+
+	// Audit, if present, enables `audit` logs.
+	//
+	// +optional
+	Audit *Audit `json:"audit"`
+}
+
+type Application struct {
+	// Namespaces is a list of namespaces from which to collect application logs.
+	// If the list is empty, logs are collected from all namespaces.
+	//
+	// +optional
+	Namespaces []string `json:"namespaces"`
+}
+
+// Infrastructure enables infrastructure logs. Filtering may be added in future.
+type Infrastructure struct{}
+
+// Audit enables audit logs. Filtering may be added in future.
+type Audit struct{}
+
+// Output defines a destination for log messages.
+type OutputSpec struct {
+	// Name used to refer to the output from a `pipeline`.
+	//
+	// +kubebuilder:validation:minLength:=1
+	// +required
+	Name string `json:"name"`
+
+	// Type of output plugin.
+	//
+	// +kubebuilder:validation:Enum:=syslog;fluentdForward;elasticsearch;kafka
+	// +required
+	Type string `json:"type"`
+
+	// URL to send log messages to.
+	//
+	// Must be an absolute URL, with a scheme. Valid URL schemes depend on `type`.
+	// Special schemes 'tcp', 'udp' and 'tls' are used for output types that don't
+	// define their own URL scheme.  Example:
+	//
+	//     { type: syslog, url: tls://syslog.example.com:1234 }
+	//
+	// TLS with server authentication is enabled by the URL scheme, for
+	// example 'tls' or 'https'.  See `secret` for TLS client authentication.
+	//
+	// +optional
+	URL string `json:"url"`
+
+	OutputTypeSpec `json:",inline"`
+
+	// Secret for secure communication.
+	// Secrets must be stored in the namespace containing the cluster logging operator.
+	//
+	// Client-authenticated TLS is enabled if the secret contains keys `tls.crt`,
+	// `tls.key` and `ca.crt`. Output types with password authentication will use
+	// keys `password` and `username`, not the exposed 'username@password' part of
+	// the `url`.
+	//
+	// +optional
+	Secret *OutputSecretSpec `json:"secret,omitempty"`
+}
+
+// OutputSecretSpec is a secret reference containing name only, no namespace.
+type OutputSecretSpec struct {
+	// Name of a secret in the namespace configured for log forwarder secrets.
+	//
+	// +required
+	Name string `json:"name"`
+}
+
+type PipelineSpec struct {
+	// OutputRefs lists the names (`output.name`) of outputs from this pipeline.
+	//
+	// The following built-in names are always available:
+	//
+	// 'default' Output to the default log store provided by ClusterLogging.
+	//
+	// +required
+	OutputRefs []string `json:"outputRefs"`
+
+	// InputRefs lists the names (`input.name`) of inputs to this pipeline.
+	//
+	// The following built-in input names are always available:
+	//
+	// `application` selects all logs from application pods.
+	//
+	// `infrastructure` selects logs from openshift and kubernetes pods and some node logs.
+	//
+	// `audit` selects node logs related to security audits.
+	//
+	// +required
+	InputRefs []string `json:"inputRefs"`
+
+	// Name is optional, but must be unique in the `pipelines` list if provided.
+	//
+	// +optional
+	Name string `json:"name,omitempty"`
+}
+
+// ClusterLogForwarderList is a list of ClusterLogForwarders
+//
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+type ClusterLogForwarderList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []ClusterLogForwarder `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&ClusterLogForwarder{}, &ClusterLogForwarderList{})
+}

--- a/pkg/apis/logging/v1/cluster_log_forwarder_types_test.go
+++ b/pkg/apis/logging/v1/cluster_log_forwarder_types_test.go
@@ -1,0 +1,145 @@
+package v1_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
+	. "github.com/openshift/cluster-logging-operator/test"
+)
+
+var _ = Describe("ClusterLogForwarder", func() {
+	It("serializes with conditions correctly", func() {
+		forwarder := ClusterLogForwarder{
+			Spec: ClusterLogForwarderSpec{
+				Pipelines: []PipelineSpec{
+					{
+						InputRefs:  []string{InputNameApplication},
+						OutputRefs: []string{"X", "Y"},
+					},
+					{
+						InputRefs:  []string{InputNameInfrastructure, InputNameAudit},
+						OutputRefs: []string{"Y", "Z"},
+					},
+					{
+						InputRefs:  []string{InputNameAudit},
+						OutputRefs: []string{"X", "Z"},
+					},
+				},
+			},
+			Status: ClusterLogForwarderStatus{
+				Conditions: NewConditions(Condition{
+					Type:   "Bad",
+					Reason: "NotGood",
+					Status: "True",
+				}),
+				Inputs: NamedConditions{
+					"MyInput": NewConditions(Condition{
+						Type:   "Broken",
+						Reason: "InputBroken",
+						Status: "True",
+					}),
+				},
+			},
+		}
+		// Reset the timestamps so we get a predicatble output
+		t := metav1.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)
+		forwarder.Status.Conditions[0].LastTransitionTime = t
+		forwarder.Status.Inputs["MyInput"][0].LastTransitionTime = t
+		Expect(YAMLString(forwarder)).To(EqualLines(`
+  metadata:
+    creationTimestamp: null
+  spec:
+    pipelines:
+    - inputRefs:
+      - application
+      outputRefs:
+      - X
+      - "Y"
+    - inputRefs:
+      - infrastructure
+      - audit
+      outputRefs:
+      - "Y"
+      - Z
+    - inputRefs:
+      - audit
+      outputRefs:
+      - X
+      - Z
+  status:
+    conditions:
+    - lastTransitionTime: "1999-01-01T00:00:00Z"
+      reason: NotGood
+      status: "True"
+      type: Bad
+    inputs:
+      MyInput:
+      - lastTransitionTime: "1999-01-01T00:00:00Z"
+        reason: InputBroken
+        status: "True"
+        type: Broken
+
+`))
+		Expect(JSONString(forwarder)).To(EqualLines(`{
+    "metadata": {
+      "creationTimestamp": null
+    },
+    "spec": {
+      "pipelines": [
+        {
+          "outputRefs": [
+            "X",
+            "Y"
+          ],
+          "inputRefs": [
+            "application"
+          ]
+        },
+        {
+          "outputRefs": [
+            "Y",
+            "Z"
+          ],
+          "inputRefs": [
+            "infrastructure",
+            "audit"
+          ]
+        },
+        {
+          "outputRefs": [
+            "X",
+            "Z"
+          ],
+          "inputRefs": [
+            "audit"
+          ]
+        }
+      ]
+    },
+    "status": {
+      "conditions": [
+        {
+          "type": "Bad",
+          "status": "True",
+          "reason": "NotGood",
+          "lastTransitionTime": "1999-01-01T00:00:00Z"
+        }
+      ],
+      "inputs": {
+        "MyInput": [
+          {
+            "type": "Broken",
+            "status": "True",
+            "reason": "InputBroken",
+            "lastTransitionTime": "1999-01-01T00:00:00Z"
+          }
+        ]
+      }
+    }
+  }`))
+	})
+})

--- a/pkg/apis/logging/v1/output_types.go
+++ b/pkg/apis/logging/v1/output_types.go
@@ -1,0 +1,121 @@
+package v1
+
+// Output type constants, must match JSON tags of OutputTypeSpec fields.
+const (
+	OutputTypeElasticsearch  = "elasticsearch"
+	OutputTypeFluentdForward = "fluentdForward"
+	OutputTypeSyslog         = "syslog"
+	OutputTypeKafka          = "kafka"
+)
+
+// NOTE: The Enum validation on OutputSpec.Type must be updated if the list of
+// known types changes.
+
+// OutputTypeSpec is a union of optional additional configuration specific to an
+// output type. The fields of this struct define the set of known output types.
+type OutputTypeSpec struct {
+	// +optional
+	Syslog *Syslog `json:"syslog,omitempty"`
+	// +optional
+	FluentdForward *FluentdForward `json:"fluentdForward,omitempty"`
+	// +optional
+	Elasticsearch *Elasticsearch `json:"elasticsearch,omitempty"`
+	// +optional
+	Kafka *Kafka `json:"kafka,omitempty"`
+}
+
+// Syslog provides optional extra properties for output type `syslog`
+type Syslog struct {
+	// Severity to set on outgoing syslog records.
+	//
+	// Severity values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1
+	// The value can be a decimal integer or one of these case-insensitive keywords:
+	//
+	//     Emergency Alert Critical Error Warning Notice Informational Debug
+	//
+	// +optional
+	Severity string `json:"severity,omitempty"`
+
+	// Facility to set on outgoing syslog records.
+	//
+	// Facility values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1.
+	// The value can be a decimal integer. Facility keywords are not standardized,
+	// this API recognizes at least the following case-insensitive keywords
+	// (defined by https://en.wikipedia.org/wiki/Syslog#Facility_Levels):
+	//
+	//     kernel user mail daemon auth syslog lpr news
+	//     uucp cron authpriv ftp ntp security console solaris-cron
+	//     local0 local1 local2 local3 local4 local5 local6 local7
+	//
+	// +optional
+	Facility string `json:"facility,omitempty"`
+
+	// TrimPrefix is a prefix to trim from the tag.
+	//
+	// +optional
+	TrimPrefix string `json:"trimPrefix,omitempty"`
+
+	// Tag specifies a record field to use as tag.
+	//
+	// +optional
+	Tag string `json:"tag,omitempty"`
+
+	// PayloadKey specifies record field to use as payload.
+	//
+	// +optional
+	PayloadKey string `json:"payloadKey,omitempty"`
+
+	// Rfc specifies the rfc to be used for sending syslog
+	//
+	// Rfc values can be one of:
+	//  - RFC3164 (https://tools.ietf.org/html/rfc3164)
+	//  - RFC5424 (https://tools.ietf.org/html/rfc5424)
+	//
+	// If unspecified, RFC5424 will be assumed.
+	//
+	// +kubebuilder:validation:Enum:=RFC3164;RFC5424
+	// +kubebuilder:default:=RFC5424
+	// +optional
+	RFC string `json:"rfc,omitempty"`
+
+	// AppName is APP-NAME part of the syslog-msg header
+	//
+	// AppName needs to be specified if using rfc5424
+	//
+	// +optional
+	AppName string `json:"appName,omitempty"`
+
+	// ProcID is PROCID part of the syslog-msg header
+	//
+	// ProcID needs to be specified if using rfc5424
+	//
+	// +optional
+	ProcID string `json:"procID,omitempty"`
+
+	// MsgID is MSGID part of the syslog-msg header
+	//
+	// MsgID needs to be specified if using rfc5424
+	//
+	// +optional
+	MsgID string `json:"msgID,omitempty"`
+}
+
+// Kafka provides optional extra properties for `type: kafka`
+type Kafka struct {
+	// Topic specifies the target topic to send logs to.
+	//
+	// +optional
+	Topic string `json:"topic,omitempty"`
+
+	// Brokers specifies the list of brokers
+	// to register in addition to the main output URL
+	// on initial connect to enhance reliability.
+	//
+	// +optional
+	Brokers []string `json:"brokers,omitempty"`
+}
+
+// Placeholders for configuration of other types
+
+type FluentdForward struct{}
+type Elasticsearch struct{}

--- a/pkg/apis/logging/v1/output_types_test.go
+++ b/pkg/apis/logging/v1/output_types_test.go
@@ -1,0 +1,25 @@
+package v1_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
+)
+
+type handler struct{ what interface{} }
+
+func (h *handler) ElasticSearch(o *Elasticsearch) error   { h.what = o; return nil }
+func (h *handler) FluentdForward(o *FluentdForward) error { h.what = o; return nil }
+func (h *handler) Syslog(o *Syslog) error                 { h.what = o; return nil }
+func (h *handler) Kafka(o *Kafka) error                   { h.what = o; return nil }
+
+var _ = Describe("OutputSpec", func() {
+	It("recognizes valid type names", func() {
+		for _, s := range []string{OutputTypeElasticsearch, OutputTypeFluentdForward, OutputTypeSyslog} {
+			Expect(IsOutputTypeName(s)).To(BeTrue(), "expect recognize %s", s)
+		}
+	})
+	It("rejects unknown type", func() {
+		Expect(IsOutputTypeName("bad")).To(BeFalse())
+	})
+})


### PR DESCRIPTION
This is an artificial PR to separate the ClusterLogForwarder API code for review purposes.